### PR TITLE
Swagger/OpenAPI for backend

### DIFF
--- a/Internships Diagram.sql
+++ b/Internships Diagram.sql
@@ -1,30 +1,40 @@
-CREATE TABLE internships (
-  `id` integer NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'internship id',
-  `company` varchar(255) COMMENT 'Agoda',
-  `position` varchar(255) COMMENT 'Backend, Frontend, Fullstack',
-  `skill_required` varchar(255) COMMENT 'scala, sql, docker'
-  'website' varchar(255) COMMENT 'www.agoda.com',
-  'deadline' date COMMENT '2024-03-31 or NULL for no deadline',
-  'start' date COMMENT '2024-03-31',
-  'end' date COMMENT '2024-03-31',
-  'author_id' integer FOREIGN KEY REFERENCES users(`id`)
+CREATE TABLE internships
+(
+    id             integer NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'internship id',
+    company        varchar(255) COMMENT 'Agoda',
+    position       varchar(255) COMMENT 'Backend, Frontend, Fullstack',
+    skill_required varchar(255) COMMENT 'scala, sql, docker',
+    website        varchar(255) COMMENT 'www.agoda.com',
+    deadline       date COMMENT '2024-03-31 or NULL for no deadline',
+    time_period_id integer FOREIGN KEY REFERENCES time_periods(id),
+    author_id      integer FOREIGN KEY REFERENCES users(id),
+    flagged        boolean DEFAULT false COMMENT 'whether or not internship flagged',
+    flagged_amount integer DEFAULT 0 COMMENT 'to order by most flagged'
+);
+
+CREATE TABLE time_periods
+(
+    id         integer      NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name       varchar(255) NOT NULL COMMENT 'eg. T1_2024-2024',
+    start_date date         NOT NULL,
+    end_date   date         NOT NULL
 );
 
 
-CREATE TABLE roles (
-  `id` integer PRIMARY KEY COMMENT '1 for students',
-  `role` varchar(255) COMMENT 'student, admin, professor, recuiter'
+CREATE TABLE roles
+(
+    id   integer PRIMARY KEY COMMENT '1 for students',
+    role varchar(255) COMMENT 'student, admin, professor, recruiter'
 );
 
-CREATE TABLE users (
-  `id` integer NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  `first_name` varchar(255),
-  `last_name` varchar(255),
-  `username` varchar(255),
-  `password` varchar(255) COMMENT 'hashed password',
-  `role_id` integer DEFAULT 0 FOREIGN KEY REFERENCES roles(`id`),
-  `intern_accepted` integer DEFAULT null COMMENT 'eg. 12 as company id',
-  'gpa' float DEFAULT null,
-  'start' date DEFAULT null,
-  'end' date DEFAULT null
+CREATE TABLE users
+(
+    id                        integer NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    first_name                varchar(255),
+    last_name                 varchar(255),
+    username                  varchar(255),
+    password                  varchar(255) COMMENT 'hashed password',
+    role_id                   integer DEFAULT 0 FOREIGN KEY REFERENCES roles(id),
+    gpa                       float   DEFAULT null,
+    internship_time_period_id integer FOREIGN KEY REFERENCES time_periods(id),
 );

--- a/openapi/backend-api.yaml
+++ b/openapi/backend-api.yaml
@@ -10,7 +10,7 @@ paths:
       tags:
         - Internship
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '200':
           description: A list of internships
@@ -26,7 +26,7 @@ paths:
       tags:
         - Internship
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       requestBody:
         required: true
         content:
@@ -51,7 +51,7 @@ paths:
           schema:
             type: integer
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '200':
           description: Retrieved internship
@@ -73,7 +73,7 @@ paths:
           schema:
             type: integer
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       requestBody:
         required: true
         content:
@@ -99,7 +99,7 @@ paths:
           schema:
             type: integer
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '204':
           description: Internship deleted successfully
@@ -118,7 +118,7 @@ paths:
           schema:
             type: integer
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '200':
           description: Internship flagged successfully
@@ -137,7 +137,7 @@ paths:
           schema:
             type: integer
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '200':
           description: A list of internships for the given time period
@@ -149,25 +149,6 @@ paths:
                   $ref: '#/components/schemas/Internship'
         '404':
           description: Time period not found
-  /internships/{id}/flag:
-    post:
-      summary: Flag an internship
-      tags:
-        - Internship
-      parameters:
-        - in: path
-          name: id
-          required: true
-          description: ID of the internship to flag
-          schema:
-            type: integer
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: Internship flagged successfully
-        '404':
-          description: Internship not found
   /users/register:
     post:
       summary: Register a new user
@@ -219,7 +200,7 @@ paths:
       tags:
         - User
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '200':
           description: Current user information
@@ -235,7 +216,7 @@ paths:
       tags:
         - User
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       requestBody:
         required: true
         content:
@@ -255,7 +236,7 @@ paths:
       tags:
         - Admin
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '200':
           description: Statistics retrieved successfully
@@ -272,7 +253,7 @@ paths:
           schema:
             type: integer
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '204':
           description: User deleted successfully
@@ -284,11 +265,11 @@ paths:
       tags:
         - Admin
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '200':
           description: Flagged internships retrieved successfully
-  /admin/internships/{id}:
+  /admin/delete_internship/{id}:
     delete:
       summary: Delete an internship (for admin)
       tags:
@@ -301,7 +282,7 @@ paths:
           schema:
             type: integer
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '204':
           description: Internship deleted successfully
@@ -313,7 +294,7 @@ paths:
       tags:
         - Admin
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       requestBody:
         required: true
         content:
@@ -338,7 +319,7 @@ paths:
           schema:
             type: integer
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '204':
           description: Time period deleted successfully
@@ -363,7 +344,7 @@ paths:
           schema:
             type: integer
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         '200':
           description: User's role changed successfully
@@ -419,12 +400,8 @@ components:
           type: integer
         gpa:
           type: number
-        start:
-          type: string
-          format: date
-        end:
-          type: string
-          format: date
+        internship_time_period_id:
+          type: integer
     TimePeriod:
       type: object
       properties:

--- a/openapi/backend-api.yaml
+++ b/openapi/backend-api.yaml
@@ -1,0 +1,443 @@
+openapi: 3.0.0
+info:
+  title: MUIC CS Internship Backend API
+  description: API documentation for a site that allows MUIC computer science students to post and find internships.
+  version: 1.0.0
+paths:
+  /internships:
+    get:
+      summary: Retrieve all internships
+      tags:
+        - Internship
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A list of internships
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Internship'
+  /internships/create_internship:
+    post:
+      summary: Create a new internship
+      tags:
+        - Internship
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Internship'
+      responses:
+        '201':
+          description: Internship created successfully
+        '400':
+          description: Invalid request body
+  /internships/{id}:
+    get:
+      summary: Retrieve an internship by ID
+      tags:
+        - Internship
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the internship to retrieve
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Retrieved internship
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Internship'
+        '404':
+          description: Internship not found
+    put:
+      summary: Update an internship
+      tags:
+        - Internship
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the internship to update
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Internship'
+      responses:
+        '200':
+          description: Internship updated successfully
+        '400':
+          description: Invalid request body
+        '404':
+          description: Internship not found
+    delete:
+      summary: Delete an internship
+      tags:
+        - Internship
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the internship to delete
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Internship deleted successfully
+        '404':
+          description: Internship not found
+  /internships/flag/{id}:
+    post:
+      summary: Flag an internship
+      tags:
+        - Internship
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the internship to flag
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Internship flagged successfully
+        '404':
+          description: Internship not found
+  /internships/time_period/{time_period_id}:
+    get:
+      summary: Retrieve all internships for a given time period
+      tags:
+        - Internship
+      parameters:
+        - in: path
+          name: time_period_id
+          required: true
+          description: ID of the time period to retrieve internships for
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A list of internships for the given time period
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Internship'
+        '404':
+          description: Time period not found
+  /internships/{id}/flag:
+    post:
+      summary: Flag an internship
+      tags:
+        - Internship
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the internship to flag
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Internship flagged successfully
+        '404':
+          description: Internship not found
+  /users/register:
+    post:
+      summary: Register a new user
+      tags:
+        - User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '201':
+          description: User registered successfully
+        '400':
+          description: Invalid request body
+  /users/login:
+    post:
+      summary: Log in a user
+      tags:
+        - User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: User logged in successfully
+        '401':
+          description: Unauthorized - invalid credentials
+  /users/logout:
+    post:
+      summary: Log out the current user
+      tags:
+        - User
+      responses:
+        '200':
+          description: User logged out successfully
+  /users/get_current_user:
+    get:
+      summary: Get current user information
+      tags:
+        - User
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current user information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          description: Unauthorized - user not logged in
+  /users/edit_profile:
+    put:
+      summary: Edit current user's profile
+      tags:
+        - User
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '200':
+          description: User profile updated successfully
+        '400':
+          description: Invalid request body
+        '401':
+          description: Unauthorized - user not logged in
+  /admin/statistics:
+    get:
+      summary: Get statistics (for admin)
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Statistics retrieved successfully
+  /admin/delete_user/{user_id}:
+    delete:
+      summary: Delete a user (for admin)
+      tags:
+        - Admin
+      parameters:
+        - in: path
+          name: user_id
+          required: true
+          description: ID of the user to delete
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: User deleted successfully
+        '404':
+          description: User not found
+  /admin/flagged_internships:
+    get:
+      summary: View flagged internships (for admin)
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Flagged internships retrieved successfully
+  /admin/internships/{id}:
+    delete:
+      summary: Delete an internship (for admin)
+      tags:
+        - Admin
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the internship to delete
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Internship deleted successfully
+        '404':
+          description: Internship not found
+  /admin/add_time_period:
+    post:
+      summary: Add a new time period (for admin)
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimePeriod'
+      responses:
+        '201':
+          description: Time period added successfully
+        '400':
+          description: Invalid request body
+  /admin/delete_time_period/{time_period_id}:
+    delete:
+      summary: Delete a time period (for admin)
+      tags:
+        - Admin
+      parameters:
+        - in: path
+          name: time_period_id
+          required: true
+          description: ID of the time period to delete
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Time period deleted successfully
+        '404':
+          description: Time period not found
+  /admin/change_role/{user_id}:
+    put:
+      summary: Change user's role (for admin)
+      tags:
+        - Admin
+      parameters:
+        - in: path
+          name: user_id
+          required: true
+          description: ID of the user whose role will be changed
+          schema:
+            type: integer
+        - in: query
+          name: role_id
+          required: true
+          description: ID of the new role to assign to the user
+          schema:
+            type: integer
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: User's role changed successfully
+        '400':
+          description: Invalid role ID or user ID
+        '404':
+          description: User not found
+components:
+  schemas:
+    Internship:
+      type: object
+      properties:
+        id:
+          type: integer
+        company:
+          type: string
+          example: "Agoda"
+        position:
+          type: string
+          example: "Software Engineer"
+        skill_required:
+          type: string
+          example: "Python, GoLang, Ruby, JavaScript, bash, PowerShell"
+        website:
+          type: string
+          example: "https://careersatagoda.com/job/5418025-cooperative-internship-2024-software-engineer-intern-infrastructure/"
+        deadline:
+          type: string
+          format: date
+        time_period_id:
+          type: integer
+        author_id:
+          type: integer
+        flagged:
+          type: boolean
+          example: false
+        flagged_amount:
+          type: integer
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        first_name:
+          type: string
+        last_name:
+          type: string
+        username:
+          type: string
+        password:
+          type: string
+        role_id:
+          type: integer
+        gpa:
+          type: number
+        start:
+          type: string
+          format: date
+        end:
+          type: string
+          format: date
+    TimePeriod:
+      type: object
+      properties:
+        name:
+          type: string
+        start_date:
+          type: string
+          format: date
+        end_date:
+          type: string
+          format: date
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
Backend API definitions.

Made some database changes that hopefully make sense after creating API.

- Reformatted so that the linter would lint properly.
- Added time periods table so that we would have fixed dates instead of specifying the date every time. Added this as foreign key to internship table and user table (for their desired intern time).
- Added flagged boolean to internship table + the number of times an internship has been flagged. This is so admins can fetch flagged interns and handle them appropriately (and also order them by number of flags).

As for API, we have

- Internship related: fetch, create, get by id, edit, delete, flag, fetch by time period
- User related: register, login, logout, get current user info, edit profile.
- Admin related: get site statistics, delete a user, fetch flagged internships, delete internship, add time period, remove time period, change user role.

For a better view, copy paste the whole `yaml` file into [the online Swagger editor](https://editor.swagger.io/).